### PR TITLE
Add a new stats file with print times

### DIFF
--- a/STATS.md
+++ b/STATS.md
@@ -1,0 +1,42 @@
+Estimated printing time for the pre-sliced pieces (you can still slice the pieces yourself to change the print settings):
+
+File | Printing time
+:--- | :---
+`cubo_arch.gcode` | 6h 15m 34s
+`cubo_bottom_insert_arduinoleonardo.gcode` | 10h 29m 13s
+`cubo_bottom_insert_arduinonano.gcode` | 10h 9m 57s
+`cubo_bottom_insert_arduinouno3.gcode` | 10h 29m 34s
+`cubo_bottom_insert_nopcb.gcode` | 9h 37m 40s
+`cubo_bottom_insert_rpi0.gcode` | 10h 19m 15s
+`cubo_bottom_insert_rpi3.gcode` | 10h 35m 49s
+`cubo_bottom_insert_rpi4.gcode` | 10h 35m 57s
+`cubo_bottom_insert_rpipico.gcode` | 10h 12m 35s
+`cubo_bottom_nut_arduinoleonardo.gcode` | 10h 33m 51s
+`cubo_bottom_nut_arduinonano.gcode` | 10h 14m 4s
+`cubo_bottom_nut_arduinouno3.gcode` | 10h 34m 8s
+`cubo_bottom_nut_nopcb.gcode` | 9h 41m 52s
+`cubo_bottom_nut_rpi0.gcode` | 10h 24m 3s
+`cubo_bottom_nut_rpi3.gcode` | 10h 40m 24s
+`cubo_bottom_nut_rpi4.gcode` | 10h 40m 34s
+`cubo_bottom_nut_rpipico.gcode` | 10h 16m 51s
+`cubo_empty.gcode` | 3h 42m 19s
+`cubo_generic.gcode` | 7h 44m 25s
+`cubo_grid_flatiron_medium.gcode` | 5h 36m 11s
+`cubo_grid_flatiron_small.gcode` | 7h 50m 13s
+`cubo_grid_gruyere_medium.gcode` | 6h 58m 58s
+`cubo_grid_gruyere_small.gcode` | 10h 9m 25s
+`cubo_grid_latitude_medium.gcode` | 4h 33m 29s
+`cubo_grid_latitude_small.gcode` | 5h 24m 1s
+`cubo_grid_longitude_medium.gcode` | 4h 34m 13s
+`cubo_grid_longitude_small.gcode` | 5h 24m 59s
+`cubo_mounting_plate_m25.gcode` | 10m 54s
+`cubo_mounting_plate_m3.gcode` | 11m 13s
+`cubo_mounting_plate_m4.gcode` | 11m 23s
+`cubo_mounting_plate_vesa.gcode` | 1h 8m 29s
+`cubo_stand_free_standing.gcode` | 19h 1m 49s
+`cubo_stand_with_base.gcode` | 1d 0h 29m 31s
+`cubo_top_insert_empty.gcode` | 5h 33m 20s
+`cubo_top_insert_filled.gcode` | 9h 36m 9s
+`cubo_top_nut_empty.gcode` | 5h 37m 46s
+`cubo_top_nut_filled.gcode` | 9h 40m 35s
+`cubo_tray.gcode` | 1d 17h 54m 43s


### PR DESCRIPTION
Currently, we're seeing these numbers:

File | Printing time
:--- | :---
`cubo_arch.gcode` | 6h 15m 34s
`cubo_bottom_insert_arduinoleonardo.gcode` | 10h 29m 13s
`cubo_bottom_insert_arduinonano.gcode` | 10h 9m 57s
`cubo_bottom_insert_arduinouno3.gcode` | 10h 29m 34s
`cubo_bottom_insert_nopcb.gcode` | 9h 37m 40s
`cubo_bottom_insert_rpi0.gcode` | 10h 19m 15s
`cubo_bottom_insert_rpi3.gcode` | 10h 35m 49s
`cubo_bottom_insert_rpi4.gcode` | 10h 35m 57s
`cubo_bottom_insert_rpipico.gcode` | 10h 12m 35s
`cubo_bottom_nut_arduinoleonardo.gcode` | 10h 33m 51s
`cubo_bottom_nut_arduinonano.gcode` | 10h 14m 4s
`cubo_bottom_nut_arduinouno3.gcode` | 10h 34m 8s
`cubo_bottom_nut_nopcb.gcode` | 9h 41m 52s
`cubo_bottom_nut_rpi0.gcode` | 10h 24m 3s
`cubo_bottom_nut_rpi3.gcode` | 10h 40m 24s
`cubo_bottom_nut_rpi4.gcode` | 10h 40m 34s
`cubo_bottom_nut_rpipico.gcode` | 10h 16m 51s
`cubo_empty.gcode` | 3h 42m 19s
`cubo_generic.gcode` | 7h 44m 25s
`cubo_grid_flatiron_medium.gcode` | 5h 36m 11s
`cubo_grid_flatiron_small.gcode` | 7h 50m 13s
`cubo_grid_gruyere_medium.gcode` | 6h 58m 58s
`cubo_grid_gruyere_small.gcode` | 10h 9m 25s
`cubo_grid_latitude_medium.gcode` | 4h 33m 29s
`cubo_grid_latitude_small.gcode` | 5h 24m 1s
`cubo_grid_longitude_medium.gcode` | 4h 34m 13s
`cubo_grid_longitude_small.gcode` | 5h 24m 59s
`cubo_mounting_plate_m25.gcode` | 10m 54s
`cubo_mounting_plate_m3.gcode` | 11m 13s
`cubo_mounting_plate_m4.gcode` | 11m 23s
`cubo_mounting_plate_vesa.gcode` | 1h 8m 29s
`cubo_stand_free_standing.gcode` | 19h 1m 49s
`cubo_stand_with_base.gcode` | 1d 0h 29m 31s
`cubo_top_insert_empty.gcode` | 5h 33m 20s
`cubo_top_insert_filled.gcode` | 9h 36m 9s
`cubo_top_nut_empty.gcode` | 5h 37m 46s
`cubo_top_nut_filled.gcode` | 9h 40m 35s
`cubo_tray.gcode` | 1d 17h 54m 43s
